### PR TITLE
Fix authentication, use new API endpoints for purifier control and prefilter change frequency

### DIFF
--- a/cowayaio/constants.py
+++ b/cowayaio/constants.py
@@ -5,12 +5,15 @@ from .str_enum import StrEnum
 class Endpoint(StrEnum):
 
     BASE_URI = 'https://iocareapp.coway.com/bizmob.iocare'
+    CLEAN_CYCLE = '/clean-cycle'
     COMMON_DEVICES = '/com/devices/'
     CONTROL = '/control'
+    CONTROL_DEVICE = '/com/control-device'
     DEVICE_LIST = '/com/user-devices'
     FILTERS = '/air/devices/'
     GET_TOKEN = '/com/token'
     HOME = '/home'
+    INITIAL_LOGIN = '/com/login-info'
     MCU_VERSION = '/com/ota'
     NEW_BASE_URI = 'https://iocareapi.iot.coway.com/api/v1'
     OAUTH_URL = "https://id.coway.com/auth/realms/cw-account/protocol/openid-connect/auth"
@@ -21,7 +24,7 @@ class Endpoint(StrEnum):
 
 class Parameter(StrEnum):
 
-    APP_VERSION = "2.3.33"
+    APP_VERSION = "2.3.36"
     CLIENT_ID = "cwid-prd-iocare-20240327"
     SERVICE_CODE = "com.coway.IOCareKor"
     CLIENT_NAME = "IOCARE"
@@ -42,6 +45,7 @@ class EndpointJSON(StrEnum):
     DEVICE_LIST = 'CWIG0304'
     FILTERS = 'CWIA0120'
     GET_TOKEN = 'CWCC0009'
+    INITIAL_LOGIN = 'CWIL0100'
     MCU_VERSION = "CWIG0615"
     PROD_SETTINGS = "CWIG0301"
     STATUS = 'CWIG0602'

--- a/cowayaio/constants.py
+++ b/cowayaio/constants.py
@@ -9,27 +9,30 @@ class Endpoint(StrEnum):
     CONTROL = '/control'
     DEVICE_LIST = '/com/user-devices'
     FILTERS = '/air/devices/'
+    GET_TOKEN = '/com/token'
     HOME = '/home'
     MCU_VERSION = '/com/ota'
     NEW_BASE_URI = 'https://iocareapi.iot.coway.com/api/v1'
     OAUTH_URL = "https://id.coway.com/auth/realms/cw-account/protocol/openid-connect/auth"
     PROD_SETTINGS = '/com/user-device-status'
-    REDIRECT_URL = "https://iocareapp.coway.com/bizmob.iocare/redirect/redirect_bridge.html"
+    REDIRECT_URL = "https://iocare-redirect.iot.coway.com/redirect_bridge.html"
     TOKEN_REFRESH = "https://iocareapi.iot.coway.com/api/v1/com/refresh-token"
-    
+
 
 class Parameter(StrEnum):
 
     APP_VERSION = "2.3.33"
-    CLIENT_ID = "cwid-prd-iocare-20220930"
+    CLIENT_ID = "cwid-prd-iocare-20240327"
     SERVICE_CODE = "com.coway.IOCareKor"
-    
+    CLIENT_NAME = "IOCARE"
+
 
 class Header(StrEnum):
 
     ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
     ACCEPT_LANG = "en-US,en;q=0.9"
     USER_AGENT = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Version/10.0 Safari/602.1"
+    CONTENT_JSON = "application/json"
 
 
 class EndpointJSON(StrEnum):
@@ -38,12 +41,12 @@ class EndpointJSON(StrEnum):
     CONTROL = 'CWIG0603'
     DEVICE_LIST = 'CWIG0304'
     FILTERS = 'CWIA0120'
-    GET_TOKEN = 'CWIL0100'
+    GET_TOKEN = 'CWCC0009'
     MCU_VERSION = "CWIG0615"
     PROD_SETTINGS = "CWIG0301"
     STATUS = 'CWIG0602'
     TOKEN_REFRESH = 'CWCC0010'
-    
+
 
 class ErrorMessages(StrEnum):
 

--- a/cowayaio/coway_client.py
+++ b/cowayaio/coway_client.py
@@ -383,6 +383,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Power command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute power command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute power command. Response: {response}'
+            )
 
     async def async_set_auto_mode(self, device_attr: dict[str, str]) -> None:
         """Set Purifier to Auto Mode."""
@@ -391,6 +401,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Auto mode command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute auto mode command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute auto mode command. Response: {response}'
+            )
 
     async def async_set_night_mode(self, device_attr: dict[str, str]) -> None:
         """Set Purifier to Night Mode."""
@@ -399,6 +419,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Night mode command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute night mode command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute night mode command. Response: {response}'
+            )
 
     async def async_set_eco_mode(self, device_attr: dict[str, str]) -> None:
         """Set Purifier to Eco Mode.
@@ -409,6 +439,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Eco mode command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute eco mode command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute eco mode command. Response: {response}'
+            )
 
     async def async_set_rapid_mode(self, device_attr: dict[str, str]) -> None:
         """Set Purifier to Rapid Mode.
@@ -419,6 +459,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Rapid mode command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute rapid mode command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute rapid mode command. Response: {response}'
+            )
 
     async def async_set_fan_speed(self, device_attr: dict[str, str], speed: str) -> None:
         """Speed can be 1, 2, or 3 represented as a string."""
@@ -427,6 +477,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Fan speed command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute fan speed command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute fan speed command. Response: {response}'
+            )
 
     async def async_set_light(self, device_attr: dict[str, str], light_on: bool) -> None:
         """Provide light_on as True for On and False for Off.
@@ -437,6 +497,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Light command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute light command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute light command. Response: {response}'
+            )
 
     async def async_set_light_mode(self, device_attr: dict[str, str], light_mode: LightMode) -> None:
         """Sets light mode for purifiers, like the 250s,
@@ -448,6 +518,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Light command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute light mode command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute light mode command. Response: {response}'
+            )
 
     async def async_set_timer(self, device_attr: dict[str, str], time: str) -> None:
         """Time, in minutes, can be 0, 60, 120, 240, or 480 represented as a string. A time of 0 sets the timer to off."""
@@ -456,6 +536,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Timer command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute set timer command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute set timer command. Response: {response}'
+            )
 
     async def async_set_smart_mode_sensitivity(self, device_attr: dict[str, str], sensitivity: str) -> None:
         """Sensitivity can be 1, 2, or 3. 1 = Sensitive, 2 = Normal, 3 = Insensitive. """
@@ -464,6 +554,16 @@ class CowayClient:
         LOGGER.debug(
             f'{device_attr.get("name")} - Sensitivity command sent. Response: {response}'
         )
+        if isinstance(response, dict):
+            if 'header' in response:
+                if 'error_code' in response['header']:
+                    raise CowayError(
+                        f'Failed to execute smart mode sensitivity command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                    )
+        else:
+            raise CowayError(
+                f'Failed to execute smart mode sensitivity command. Response: {response}'
+            )
 
 
 #####################################################################################################################################################
@@ -563,29 +663,19 @@ class CowayClient:
         """Main function to execute individual purifier control commands."""
 
         await self._check_token()
-        url = f'{Endpoint.BASE_URI}/{EndpointJSON.CONTROL}.json'
-        headers = {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Accept': 'application/json',
-            'User-Agent': Header.USER_AGENT
-        }
-        params = {
-            'barcode': device_attr.get('device_id'),
-            'dvcBrandCd': device_attr.get('device_brand'),
-            'prodName': device_attr.get('product_name'),
+        url = f'{Endpoint.NEW_BASE_URI}{Endpoint.CONTROL_DEVICE}'
+        headers = await self._construct_control_header(EndpointJSON.CONTROL)
+        data = {
+            'devId': device_attr.get('device_id'),
             'dvcTypeCd': device_attr.get('device_type'),
             'funcList': [{
-              'comdVal': value,
+              'cmdVal': value,
               'funcId': command
             }],
-            'mqttDevice': True
-        }
-        message = await self._construct_control_message(EndpointJSON.CONTROL, params)
-        data = {
-            'message': json.dumps(message)
+            'isMultiControl': False
         }
 
-        async with self._session.post(url, headers=headers, data=data, timeout=self.timeout) as resp:
+        async with self._session.post(url, headers=headers, data=json.dumps(data), timeout=self.timeout) as resp:
             response = await self._control_command_response(resp)
             return response
 
@@ -593,40 +683,43 @@ class CowayClient:
         """ Used to change the pre-filter wash frequency. Value can be 2, 3, or 4."""
 
         await self._check_token()
-        url = f'{Endpoint.BASE_URI}/{EndpointJSON.CHANGE_PRE_FILTER}.json'
-        headers = {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Accept': 'application/json',
-            'User-Agent': Header.USER_AGENT
-        }
-        params = {
-            'barcode': device_attr.get('device_id'),
-            'comdVal': value,
-            'mqttDevice': False
-        }
-        message = await self._construct_control_message(EndpointJSON.CHANGE_PRE_FILTER, params)
+        url = f'{Endpoint.NEW_BASE_URI}{Endpoint.FILTERS}{device_attr["device_id"]}{Endpoint.CLEAN_CYCLE}'
+        headers = await self._construct_control_header(EndpointJSON.CHANGE_PRE_FILTER)
         data = {
-            'message': json.dumps(message)
+            'comdVal': value,
+            'devId': device_attr.get('device_id'),
         }
 
-        async with self._session.post(url, headers=headers, data=data, timeout=self.timeout) as resp:
+        async with self._session.post(url, headers=headers, data=json.dumps(data), timeout=self.timeout) as resp:
             response = await self._control_command_response(resp)
             LOGGER.debug(
                 f'{device_attr.get("name")} - Prefilter command sent. Response: {response}'
             )
+            if isinstance(response, dict):
+                if 'header' in response:
+                    if 'error_code' in response['header']:
+                        raise CowayError(
+                            f'Failed to execute Prefilter command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                        )
+            else:
+                raise CowayError(
+                    f'Failed to execute Prefilter command. Response: {response}'
+                )
 
-    async def _construct_control_message(self, json_endpoint: str, params: dict[str, Any]) -> dict[str, Any]:
-        """Create message dict used by control and prefilter setting functions."""
+    async def _construct_control_header(self, trcode: str) -> dict[str, Any]:
+        """Construct header used by control purifier function
+        and prefilter control function
+        """
 
-        message = {
-            'header': {
-                'trcode': json_endpoint,
-                'accessToken': self.access_token,
-                'refreshToken': self.refresh_token
-            },
-            'body': params
+        headers = {
+            'Content-Type': Header.CONTENT_JSON,
+            'Accept': '*/*',
+            'accept-language': Header.ACCEPT_LANG,
+            'User-Agent': Header.USER_AGENT,
+            'trcode': trcode,
+            'authorization': f'Bearer {self.access_token}'
         }
-        return message
+        return headers
 
     @staticmethod
     async def _response(resp: ClientResponse, new_api=False) -> dict[str, Any]:

--- a/cowayaio/coway_client.py
+++ b/cowayaio/coway_client.py
@@ -679,11 +679,8 @@ class CowayClient:
             response = await self._control_command_response(resp)
             return response
 
-    async def async_change_prefilter_setting(self, device_attr: dict[str, str], value: str, return_error: bool = False) -> None:
-        """ Used to change the pre-filter wash frequency. Value can be 2, 3, or 4.
-        return_error: if you want to return the error instead of exception being
-        raised.
-        """
+    async def async_change_prefilter_setting(self, device_attr: dict[str, str], value: str) -> None:
+        """ Used to change the pre-filter wash frequency. Value can be 2, 3, or 4."""
 
         await self._check_token()
         url = f'{Endpoint.NEW_BASE_URI}{Endpoint.FILTERS}{device_attr["device_id"]}{Endpoint.CLEAN_CYCLE}'
@@ -701,17 +698,13 @@ class CowayClient:
             if isinstance(response, dict):
                 if 'header' in response:
                     if 'error_code' in response['header']:
-                        message = f'Failed to execute Prefilter command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
-                        if return_error:
-                            return message
-                        else:
-                            raise CowayError(message)
+                        raise CowayError(
+                            f'Failed to execute Prefilter command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                        )
             else:
-                message = f'Failed to execute Prefilter command. Response: {response}'
-                if return_error:
-                    return message
-                else:
-                    raise CowayError(message)
+                raise CowayError(
+                    f'Failed to execute Prefilter command. Response: {response}'
+                )
 
     async def _construct_control_header(self, trcode: str) -> dict[str, Any]:
         """Construct header used by control purifier function
@@ -783,4 +776,6 @@ class CowayClient:
         except Exception:
             response = await resp.text()
             return response
+        if resp.status != 200:
+            response = await resp.text()
         return response

--- a/cowayaio/coway_client.py
+++ b/cowayaio/coway_client.py
@@ -679,7 +679,7 @@ class CowayClient:
             response = await self._control_command_response(resp)
             return response
 
-    async def async_change_prefilter_setting(self, device_attr: dict[str, str], value: str) -> None:
+    async def async_change_prefilter_setting(self, device_attr: dict[str, str], value: int) -> None:
         """ Used to change the pre-filter wash frequency. Value can be 2, 3, or 4."""
 
         await self._check_token()

--- a/cowayaio/coway_client.py
+++ b/cowayaio/coway_client.py
@@ -679,8 +679,11 @@ class CowayClient:
             response = await self._control_command_response(resp)
             return response
 
-    async def async_change_prefilter_setting(self, device_attr: dict[str, str], value: str) -> None:
-        """ Used to change the pre-filter wash frequency. Value can be 2, 3, or 4."""
+    async def async_change_prefilter_setting(self, device_attr: dict[str, str], value: str, return_error: bool = False) -> None:
+        """ Used to change the pre-filter wash frequency. Value can be 2, 3, or 4.
+        return_error: if you want to return the error instead of exception being
+        raised.
+        """
 
         await self._check_token()
         url = f'{Endpoint.NEW_BASE_URI}{Endpoint.FILTERS}{device_attr["device_id"]}{Endpoint.CLEAN_CYCLE}'
@@ -698,14 +701,17 @@ class CowayClient:
             if isinstance(response, dict):
                 if 'header' in response:
                     if 'error_code' in response['header']:
-                        raise CowayError(
-                            f'Failed to execute Prefilter command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
-                        )
-            if isinstance(response, str):
-                LOGGER.error("Exception is being raised")
-                raise CowayError(
-                    f'Failed to execute Prefilter command. Response: {response}'
-                )
+                        message = f'Failed to execute Prefilter command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
+                        if return_error:
+                            return message
+                        else:
+                            raise CowayError(message)
+            else:
+                message = f'Failed to execute Prefilter command. Response: {response}'
+                if return_error:
+                    return message
+                else:
+                    raise CowayError(message)
 
     async def _construct_control_header(self, trcode: str) -> dict[str, Any]:
         """Construct header used by control purifier function

--- a/cowayaio/coway_client.py
+++ b/cowayaio/coway_client.py
@@ -701,7 +701,7 @@ class CowayClient:
                         raise CowayError(
                             f'Failed to execute Prefilter command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
                         )
-            else:
+            if isinstance(response, str):
                 LOGGER.error("Exception is being raised")
                 raise CowayError(
                     f'Failed to execute Prefilter command. Response: {response}'

--- a/cowayaio/coway_client.py
+++ b/cowayaio/coway_client.py
@@ -702,6 +702,7 @@ class CowayClient:
                             f'Failed to execute Prefilter command. Error code: {response["header"]["error_code"]}, Error message: {response["header"]["error_text"]}'
                         )
             else:
+                LOGGER.error("Exception is being raised")
                 raise CowayError(
                     f'Failed to execute Prefilter command. Response: {response}'
                 )

--- a/cowayaio/coway_client.py
+++ b/cowayaio/coway_client.py
@@ -690,7 +690,7 @@ class CowayClient:
             'devId': device_attr.get('device_id'),
         }
 
-        async with self._session.post(url, headers=headers, data=json.dumps(data), timeout=self.timeout) as resp:
+        async with self._session.put(url, headers=headers, data=json.dumps(data), timeout=self.timeout) as resp:
             response = await self._control_command_response(resp)
             LOGGER.debug(
                 f'{device_attr.get("name")} - Prefilter command sent. Response: {response}'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11",
+    version="0.1.11.1",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11.5",
+    version="0.1.11.6",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11.4",
+    version="0.1.11.5",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11.1",
+    version="0.1.11.2",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11.3",
+    version="0.1.11.4",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11.2",
+    version="0.1.11.3",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11.6",
+    version="0.1.11.7",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cowayaio",
-    version="0.1.11.7",
+    version="0.1.12",
     author="Robert Drinovac",
     author_email="unlisted@gmail.com",
     description="A asynchronous python library for Coway Air Purifiers ",


### PR DESCRIPTION
- Uses new redirect URL to authenticate user
- Coway deprecated purifier control and prefilter change frequency endpoints - now using new API endpoints
- Raise CowayError exception if a control command fails, as indicated in the response received from Coway servers